### PR TITLE
fix storage name and free space detection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -94,7 +94,7 @@ class RemarkablePlugin(DevicePlugin):
             "df -k | grep " + self.storage + " -m 1 | awk '{print $2}' | tr -d '\n'"
         )
         self.device_total_space = 1024 * int(stdout.read())
-        
+
         stdin, stdout, stderr = ssh.exec_command(
             "df -k | grep " + self.storage + " -m 1 | awk '{print $4}' | tr -d '\n'"
         )

--- a/__init__.py
+++ b/__init__.py
@@ -91,12 +91,15 @@ class RemarkablePlugin(DevicePlugin):
         # The version of busybox on the remarkable tablet doesn't seem to support `-B 1`,
         # so lets just get the total size in 1024-byte blocks and multiple by 1024
         stdin, stdout, stderr = ssh.exec_command(
-            "df -k | grep \"/dev/mmcblk1p7\" -m 1 | awk '{print $2}'"
+            "df -k | grep" + self.storage + " -m 1 | awk '{print $2}' | tr -d '\n'"
         )
-        self.device_total_space = 1024 * int(stdout.read())
+        # self.device_total_space = 1024 * int(stdout.read())
+        # above wasn't working and I didn't manage to convert the bytes to int for some reason
+        # afaik disk space on RM2 is fixed anyway so I hardcoded it:
+        self.device_total_space = 6884044800
 
         stdin, stdout, stderr = ssh.exec_command(
-            "df -k | grep \"/dev/mmcblk1p7\" -m 1 | awk '{print $4}'"
+            "df -k | grep " + self.storage + " -m 1 | awk '{print $4}' | tr -d '\n'"
         )
         self.device_free_space = 1024 * int(stdout.read())
 
@@ -288,6 +291,7 @@ class RemarkablePlugin(DevicePlugin):
         self.books_path: Path = Path(prefs["books_path"])
         self.metadata_path: Path = Path(prefs["metadata_path"]) / ".calibre.json"
         self.remarkable_password: str = prefs["password"]
+        self.storage: str = prefs["storage"]
 
     def free_space(self, end_session=True):
         return (self.device_free_space, -1, -1)

--- a/__init__.py
+++ b/__init__.py
@@ -91,13 +91,10 @@ class RemarkablePlugin(DevicePlugin):
         # The version of busybox on the remarkable tablet doesn't seem to support `-B 1`,
         # so lets just get the total size in 1024-byte blocks and multiple by 1024
         stdin, stdout, stderr = ssh.exec_command(
-            "df -k | grep" + self.storage + " -m 1 | awk '{print $2}' | tr -d '\n'"
+            "df -k | grep " + self.storage + " -m 1 | awk '{print $2}' | tr -d '\n'"
         )
-        # self.device_total_space = 1024 * int(stdout.read())
-        # above wasn't working and I didn't manage to convert the bytes to int for some reason
-        # afaik disk space on RM2 is fixed anyway so I hardcoded it:
-        self.device_total_space = 6884044800
-
+        self.device_total_space = 1024 * int(stdout.read())
+        
         stdin, stdout, stderr = ssh.exec_command(
             "df -k | grep " + self.storage + " -m 1 | awk '{print $4}' | tr -d '\n'"
         )

--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ class ConfigWidget(QWidget):
         self.layout.addWidget(self.password_label_msg, 4, 1)
         self.password_label.setBuddy(self.password_label_msg)
 
-        self.storage_label = QLabel("Storage ( like '/dev/mmcblk2p4' ):")
+        self.storage_label = QLabel("Storage ( like '/dev/mmcblk1p7' ):")
         self.layout.addWidget(self.storage_label, 5, 0)
         self.storage_label_msg = QLineEdit(self)
         self.storage_label_msg.setText(prefs["storage"])

--- a/config.py
+++ b/config.py
@@ -59,7 +59,6 @@ class ConfigWidget(QWidget):
     def save_settings(self):
         prefs["ip"] = self.ip_label_msg.text()
         # append an extra '/' in case it was forgotten
-        # this is why there's always that annoying extra '/' at the end >_<
         prefs["books_path"] = self.books_path_label_msg.text() + "/"
         prefs["metadata_path"] = self.metadata_path_label_msg.text() + "/"
         prefs["password"] = self.password_label_msg.text()

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ prefs.defaults["ip"] = "10.11.99.1"
 prefs.defaults["books_path"] = "/"
 prefs.defaults["metadata_path"] = "/home/root/"
 prefs.defaults["password"] = ""
-prefs.defaults["storage"] = "/dev/mmcblk2p4"
+prefs.defaults["storage"] = "/dev/mmcblk1p7"
 
 
 class ConfigWidget(QWidget):

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ prefs.defaults["ip"] = "10.11.99.1"
 prefs.defaults["books_path"] = "/"
 prefs.defaults["metadata_path"] = "/home/root/"
 prefs.defaults["password"] = ""
+prefs.defaults["storage"] = "/dev/mmcblk2p4"
 
 
 class ConfigWidget(QWidget):
@@ -44,6 +45,13 @@ class ConfigWidget(QWidget):
         self.layout.addWidget(self.password_label_msg, 4, 1)
         self.password_label.setBuddy(self.password_label_msg)
 
+        self.storage_label = QLabel("Storage ( like '/dev/mmcblk2p4' ):")
+        self.layout.addWidget(self.storage_label, 5, 0)
+        self.storage_label_msg = QLineEdit(self)
+        self.storage_label_msg.setText(prefs["storage"])
+        self.layout.addWidget(self.storage_label_msg, 5, 1)
+        self.storage_label.setBuddy(self.storage_label_msg)
+
         self.setLayout(self.layout)
         self.setGeometry(150, 150, 150, 150)
         self.setWindowTitle("Remarkable Config")
@@ -51,6 +59,8 @@ class ConfigWidget(QWidget):
     def save_settings(self):
         prefs["ip"] = self.ip_label_msg.text()
         # append an extra '/' in case it was forgotten
+        # this is why there's always that annoying extra '/' at the end >_<
         prefs["books_path"] = self.books_path_label_msg.text() + "/"
         prefs["metadata_path"] = self.metadata_path_label_msg.text() + "/"
         prefs["password"] = self.password_label_msg.text()
+        prefs["storage"] = self.storage_label_msg.text()


### PR DESCRIPTION
Hi!
I noticed my RM2 has a different name for the drive and partition than the code allowed for, so I added an extra variable to allow for the configuration of that parameter.

2nd issue: the disk space wasn't detected properly. I hardcoded 1 of the variables :grimacing: but afaik that's the only possible value, both RM1 and RM2 have the same disk space.
