### PR TITLE
Fix device space retrieving on reMarkable2

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -91,14 +91,11 @@ class RemarkablePlugin(DevicePlugin):
         # The version of busybox on the remarkable tablet doesn't seem to support `-B 1`,
         # so lets just get the total size in 1024-byte blocks and multiple by 1024
         stdin, stdout, stderr = ssh.exec_command(
-            "df -k | grep " + self.storage + " -m 1 | awk '{print $2}' | tr -d '\n'"
+            "df -k /home/root"
         )
-        self.device_total_space = 1024 * int(stdout.read())
-
-        stdin, stdout, stderr = ssh.exec_command(
-            "df -k | grep " + self.storage + " -m 1 | awk '{print $4}' | tr -d '\n'"
-        )
-        self.device_free_space = 1024 * int(stdout.read())
+        output = stdout.readlines()[-1]
+        self.device_total_space = 1024 * int(output.split()[1])
+        self.device_free_space = 1024 * int(output.split()[3])
 
         print(f"opened device: {self.document_root}")
 

--- a/__init__.py
+++ b/__init__.py
@@ -91,7 +91,7 @@ class RemarkablePlugin(DevicePlugin):
         # The version of busybox on the remarkable tablet doesn't seem to support `-B 1`,
         # so lets just get the total size in 1024-byte blocks and multiple by 1024
         stdin, stdout, stderr = ssh.exec_command(
-            "df -k /home/root"
+            "df -k " + self.storage
         )
         output = stdout.readlines()[-1]
         self.device_total_space = 1024 * int(output.split()[1])


### PR DESCRIPTION
On the reMarkable2, the device is not /dev/mmcblk1p7, so I use the path directly in `df`. I am not able to test on the first reMarkable, but I am quite confident it will work with this version of busybox too.

I rewrote a bit the way it is retrieved too, to avoid a double SSH command, and the use of pipes in command.